### PR TITLE
Fix Bug - Add necessary import

### DIFF
--- a/tasks/exchangeCoupons_task.py
+++ b/tasks/exchangeCoupons_task.py
@@ -1,4 +1,5 @@
 from BiliClient import asyncbili
+import logging
 
 async def exchangeCoupons_task(biliapi: asyncbili, 
                          task_config: dict


### PR DESCRIPTION
Add ```import logging``` to `exchangeCoupons_task.py`.

Also, there's a bug in the release version, cannot run `exchangeCoupons_task` properly.