### PR TITLE
更换公共邮件发送API

### DIFF
--- a/run_in_Actions/secrets2config.py
+++ b/run_in_Actions/secrets2config.py
@@ -94,11 +94,11 @@ if PUSH_MESSAGE:
                 "name": f"邮箱消息推送{i}",
                 "msg_separ": r"<br>",
                 "method": 0,
-                "url": "http://liuxingw.com/api/mail/api.php",
+                "url": "https://email.berfen.com/api",
                 "params": {
-                    "address": value,
-                    "name": "{title}",
-                    "certno": f"{{{msg_type}}}"
+                    "to": value,              # 收件人
+                    "title": "{title}",       # 邮件标题
+                    "text": f"{{{msg_type}}}" # 邮件内容
                 }
             })
         else:


### PR DESCRIPTION
原来的“流星云”邮件API发送邮件经常失败，于是找到了另一个同样可免Key的免费的公共邮件发送接口替代流星云。方便某些喜欢使用邮箱的同学。