### PR TITLE
使用 github action 通过 pr 自动合并上游代码

### DIFF
--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -1,0 +1,21 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '* 12 * * *' # 12:00 everyday
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: NimaQu/fork-sync@v1.3.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          owner: happy888888
+          base: master
+          head: master
+          token_merge: true
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -1,8 +1,6 @@
 name: Sync Fork
 
 on:
-  schedule:
-    - cron: '* 12 * * *' # 12:00 everyday
   workflow_dispatch: # on button click
 
 jobs:


### PR DESCRIPTION
https://github.com/tgymnich/fork-sync 用的是这个，但有个问题如果提交包含对 workflow 的更改就无法使用 github token 进行 merge 操作，我对他改了一下使用个人 token 进行 merge, 上游说近期会做这个功能，到时候再改回去，免得天天有人反方向 pr

需要在 secrets 里配置  `PERSONAL_TOKEN` 
https://github.com/settings/tokens 在这里进行获取, 权限需要给到 workflow 这个就行了

效果: https://github.com/NimaQu/BiliExp/pull/10